### PR TITLE
Fixed a minor bug where a trajectory value was read into the wrong variable

### DIFF
--- a/src/main/scala/org/quakelivedemoparser/StateReader.scala
+++ b/src/main/scala/org/quakelivedemoparser/StateReader.scala
@@ -120,7 +120,7 @@ class StateReader(bit_reader: BitReader) {
       () => { result.trajectories(0).delta(0) = Some(read_float) },
       () => { result.trajectories(0).delta(1) = Some(read_float) },
       () => { result.trajectories(0).base(2) = Some(read_float) },
-      () => { result.trajectories(0).base(1) = Some(read_float) },
+      () => { result.trajectories(1).base(1) = Some(read_float) },
       () => { result.trajectories(0).delta(2) = Some(read_float) },
       () => { result.trajectories(1).base(0) = Some(read_float) },
       () => { result.trajectories(0).gravity = Some(read_int) },


### PR DESCRIPTION
Relevant snippet Quake 3's source code:
{ NETF(pos.trTime), 32 },
{ NETF(pos.trBase[0]), 0 },
{ NETF(pos.trBase[1]), 0 },
{ NETF(pos.trDelta[0]), 0 },
{ NETF(pos.trDelta[1]), 0 },
{ NETF(pos.trBase[2]), 0 },
{ NETF(apos.trBase[1]), 0 }, // This corresponds to result.trajectories(1).base(1)
{ NETF(pos.trDelta[2]), 0 },
{ NETF(apos.trBase[0]), 0 },
